### PR TITLE
Add Comfact webhook receiver forwarding signing events to e-signing

### DIFF
--- a/src/main/java/se/sundsvall/comfactfacade/api/EventNotificationResource.java
+++ b/src/main/java/se/sundsvall/comfactfacade/api/EventNotificationResource.java
@@ -1,0 +1,42 @@
+package se.sundsvall.comfactfacade.api;
+
+import generated.se.sundsvall.comfact.EventNotification;
+import io.swagger.v3.oas.annotations.Hidden;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import se.sundsvall.comfactfacade.service.EventNotificationService;
+import se.sundsvall.dept44.common.validators.annotation.ValidMunicipalityId;
+
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+import static org.springframework.http.ResponseEntity.ok;
+
+/**
+ * Inbound webhook receiver for Comfact provider events. Called by Comfact only (account-global webhook target,
+ * with the municipality baked into the URL), never by other Sundsvall services — hence hidden from the public
+ * OpenAPI. Received events are forwarded, unchanged, to api-service-e-signing for normalization.
+ */
+@Hidden
+@RestController
+@Validated
+@RequestMapping("/{municipalityId}/webhooks")
+class EventNotificationResource {
+
+	private final EventNotificationService eventNotificationService;
+
+	EventNotificationResource(final EventNotificationService eventNotificationService) {
+		this.eventNotificationService = eventNotificationService;
+	}
+
+	@PostMapping(path = "/comfact", consumes = APPLICATION_JSON_VALUE)
+	ResponseEntity<Void> handleComfactEvent(
+		@PathVariable @ValidMunicipalityId final String municipalityId,
+		@RequestBody final EventNotification notification) {
+		eventNotificationService.handleComfactEvent(municipalityId, notification);
+		return ok().build();
+	}
+}

--- a/src/main/java/se/sundsvall/comfactfacade/integration/esigning/EsigningClient.java
+++ b/src/main/java/se/sundsvall/comfactfacade/integration/esigning/EsigningClient.java
@@ -1,0 +1,25 @@
+package se.sundsvall.comfactfacade.integration.esigning;
+
+import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import se.sundsvall.comfactfacade.integration.esigning.configuration.EsigningConfiguration;
+import se.sundsvall.comfactfacade.integration.esigning.model.ComfactEventNotification;
+
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+import static se.sundsvall.comfactfacade.integration.esigning.configuration.EsigningConfiguration.CLIENT_ID;
+
+@CircuitBreaker(name = CLIENT_ID)
+@FeignClient(name = CLIENT_ID, url = "${integration.esigning.url}", configuration = EsigningConfiguration.class)
+public interface EsigningClient {
+
+	/**
+	 * Forward a Comfact signing event to api-service-e-signing.
+	 *
+	 * @param municipalityId the municipality id
+	 * @param event          the flattened Comfact event
+	 */
+	@PostMapping(path = "/{municipalityId}/e-signing/webhooks/comfact", consumes = APPLICATION_JSON_VALUE)
+	void forwardComfactEvent(@PathVariable String municipalityId, ComfactEventNotification event);
+}

--- a/src/main/java/se/sundsvall/comfactfacade/integration/esigning/EsigningIntegration.java
+++ b/src/main/java/se/sundsvall/comfactfacade/integration/esigning/EsigningIntegration.java
@@ -1,0 +1,18 @@
+package se.sundsvall.comfactfacade.integration.esigning;
+
+import org.springframework.stereotype.Service;
+import se.sundsvall.comfactfacade.integration.esigning.model.ComfactEventNotification;
+
+@Service
+public class EsigningIntegration {
+
+	private final EsigningClient esigningClient;
+
+	public EsigningIntegration(final EsigningClient esigningClient) {
+		this.esigningClient = esigningClient;
+	}
+
+	public void forwardComfactEvent(final String municipalityId, final ComfactEventNotification event) {
+		esigningClient.forwardComfactEvent(municipalityId, event);
+	}
+}

--- a/src/main/java/se/sundsvall/comfactfacade/integration/esigning/configuration/EsigningConfiguration.java
+++ b/src/main/java/se/sundsvall/comfactfacade/integration/esigning/configuration/EsigningConfiguration.java
@@ -1,0 +1,25 @@
+package se.sundsvall.comfactfacade.integration.esigning.configuration;
+
+import java.util.Set;
+import org.springframework.cloud.openfeign.FeignBuilderCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import se.sundsvall.dept44.configuration.feign.FeignConfiguration;
+import se.sundsvall.dept44.configuration.feign.FeignMultiCustomizer;
+import se.sundsvall.dept44.configuration.feign.decoder.ProblemErrorDecoder;
+
+@Import(FeignConfiguration.class)
+public class EsigningConfiguration {
+
+	public static final String CLIENT_ID = "esigning";
+
+	@Bean
+	FeignBuilderCustomizer feignBuilderCustomizer(final EsigningProperties properties, final ClientRegistrationRepository clientRegistrationRepository) {
+		return FeignMultiCustomizer.create()
+			.withErrorDecoder(new ProblemErrorDecoder(CLIENT_ID))
+			.withRetryableOAuth2InterceptorForClientRegistration(clientRegistrationRepository.findByRegistrationId(CLIENT_ID), Set.of())
+			.withRequestTimeoutsInSeconds(properties.connectTimeout(), properties.readTimeout())
+			.composeCustomizersToOne();
+	}
+}

--- a/src/main/java/se/sundsvall/comfactfacade/integration/esigning/configuration/EsigningProperties.java
+++ b/src/main/java/se/sundsvall/comfactfacade/integration/esigning/configuration/EsigningProperties.java
@@ -1,0 +1,9 @@
+package se.sundsvall.comfactfacade.integration.esigning.configuration;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties("integration.esigning")
+public record EsigningProperties(
+	int connectTimeout,
+	int readTimeout) {
+}

--- a/src/main/java/se/sundsvall/comfactfacade/integration/esigning/model/ComfactEventNotification.java
+++ b/src/main/java/se/sundsvall/comfactfacade/integration/esigning/model/ComfactEventNotification.java
@@ -1,0 +1,28 @@
+package se.sundsvall.comfactfacade.integration.esigning.model;
+
+import java.time.OffsetDateTime;
+import se.sundsvall.comfactfacade.api.model.Document;
+
+/**
+ * A Comfact signing event, flattened from Comfact's {@code EventNotification} and forwarded to
+ * api-service-e-signing (which normalizes it into its own provider-neutral event).
+ *
+ * @param eventTrigger      the Comfact event trigger (e.g. {@code signingInstanceCompleted})
+ * @param signingInstanceId the Comfact signing instance id
+ * @param customerReference the customer reference (Postportalen MessageId) echoed back by Comfact
+ * @param statusCode        the Comfact status code of the signing instance
+ * @param expires           when the signing instance expires
+ * @param signatory         the acting signatory, present on signatory events
+ * @param signedDocument    the signed document, present on a completed event
+ * @param timestamp         when the event occurred
+ */
+public record ComfactEventNotification(
+	String eventTrigger,
+	String signingInstanceId,
+	String customerReference,
+	String statusCode,
+	OffsetDateTime expires,
+	ComfactSignatory signatory,
+	Document signedDocument,
+	OffsetDateTime timestamp) {
+}

--- a/src/main/java/se/sundsvall/comfactfacade/integration/esigning/model/ComfactSignatory.java
+++ b/src/main/java/se/sundsvall/comfactfacade/integration/esigning/model/ComfactSignatory.java
@@ -1,0 +1,11 @@
+package se.sundsvall.comfactfacade.integration.esigning.model;
+
+/**
+ * A signatory referenced by a Comfact event, forwarded to api-service-e-signing.
+ *
+ * @param partyId the party that acted
+ * @param action  the Comfact action ({@code approved} / {@code declined}), when present
+ * @param reason  the reason given for the action, when present
+ */
+public record ComfactSignatory(String partyId, String action, String reason) {
+}

--- a/src/main/java/se/sundsvall/comfactfacade/service/EventNotificationMapper.java
+++ b/src/main/java/se/sundsvall/comfactfacade/service/EventNotificationMapper.java
@@ -1,0 +1,54 @@
+package se.sundsvall.comfactfacade.service;
+
+import generated.se.sundsvall.comfact.EventNotification;
+import generated.se.sundsvall.comfact.SignatoryAction;
+import generated.se.sundsvall.comfact.SignatoryInfo;
+import generated.se.sundsvall.comfact.Status;
+import java.util.Base64;
+import java.util.Optional;
+import se.sundsvall.comfactfacade.api.model.Document;
+import se.sundsvall.comfactfacade.integration.esigning.model.ComfactEventNotification;
+import se.sundsvall.comfactfacade.integration.esigning.model.ComfactSignatory;
+
+/**
+ * Flattens Comfact's generated {@link EventNotification} into the {@link ComfactEventNotification} forwarded to
+ * api-service-e-signing.
+ */
+public final class EventNotificationMapper {
+
+	private EventNotificationMapper() {}
+
+	public static ComfactEventNotification toEsigningEvent(final EventNotification notification) {
+		final var info = notification.getSigningInstanceInfo();
+
+		return new ComfactEventNotification(
+			notification.getEventTrigger().getValue(),
+			info.getSigningInstanceId(),
+			info.getCustomerReferenceNumber(),
+			Optional.ofNullable(info.getStatus()).map(Status::getValue).orElse(null),
+			info.getExpires(),
+			toSignatory(notification.getSignatoryInfo()),
+			toDocument(notification.getSignedDocument()),
+			notification.getTimestamp());
+	}
+
+	static ComfactSignatory toSignatory(final SignatoryInfo signatoryInfo) {
+		return Optional.ofNullable(signatoryInfo)
+			.map(s -> new ComfactSignatory(
+				s.getPartyId(),
+				Optional.ofNullable(s.getSignatoryAction()).map(action -> action.getAction().getValue()).orElse(null),
+				Optional.ofNullable(s.getSignatoryAction()).map(SignatoryAction::getReason).orElse(null)))
+			.orElse(null);
+	}
+
+	static Document toDocument(final generated.se.sundsvall.comfact.Document document) {
+		return Optional.ofNullable(document)
+			.map(d -> Document.builder()
+				.withName(d.getDocumentName())
+				.withFileName(d.getFileName())
+				.withMimeType(d.getMimeType())
+				.withContent(Optional.ofNullable(d.getContent()).map(Base64.getEncoder()::encodeToString).orElse(null))
+				.build())
+			.orElse(null);
+	}
+}

--- a/src/main/java/se/sundsvall/comfactfacade/service/EventNotificationService.java
+++ b/src/main/java/se/sundsvall/comfactfacade/service/EventNotificationService.java
@@ -1,0 +1,19 @@
+package se.sundsvall.comfactfacade.service;
+
+import generated.se.sundsvall.comfact.EventNotification;
+import org.springframework.stereotype.Service;
+import se.sundsvall.comfactfacade.integration.esigning.EsigningIntegration;
+
+@Service
+public class EventNotificationService {
+
+	private final EsigningIntegration esigningIntegration;
+
+	public EventNotificationService(final EsigningIntegration esigningIntegration) {
+		this.esigningIntegration = esigningIntegration;
+	}
+
+	public void handleComfactEvent(final String municipalityId, final EventNotification notification) {
+		esigningIntegration.forwardComfactEvent(municipalityId, EventNotificationMapper.toEsigningEvent(notification));
+	}
+}

--- a/src/main/resources/application-it.yml
+++ b/src/main/resources/application-it.yml
@@ -10,6 +10,8 @@ integration:
     url: http://localhost:${wiremock.server.port:}
   party:
     url: http://localhost:${wiremock.server.port:}/party
+  esigning:
+    url: http://localhost:${wiremock.server.port:}/esigning
 
 spring:
   security:
@@ -20,10 +22,15 @@ spring:
             token-uri: http://localhost:${wiremock.server.port:}/api-gateway/token
           comfact:
             token-uri: http://localhost:${wiremock.server.port:}/api-gateway/token
+          esigning:
+            token-uri: http://localhost:${wiremock.server.port:}/api-gateway/token
         registration:
           party:
             client-id: the-client-id
             client-secret: the-client-secret
           comfact:
             client-id: Spänks!
+            client-secret: the-client-secret
+          esigning:
+            client-id: the-client-id
             client-secret: the-client-secret

--- a/src/main/resources/application-junit.yml
+++ b/src/main/resources/application-junit.yml
@@ -11,6 +11,8 @@ integration:
     url: http://comfact.url
   party:
     url: http://party.url
+  esigning:
+    url: http://esigning.url
 
 spring:
   security:
@@ -21,10 +23,15 @@ spring:
             token-uri: http://token.url
           comfact:
             token-uri: http://token.url
+          esigning:
+            token-uri: http://token.url
         registration:
           party:
             client-id: the-client-id
             client-secret: the-client-secret
           comfact:
+            client-id: the-client-id
+            client-secret: the-client-secret
+          esigning:
             client-id: the-client-id
             client-secret: the-client-secret

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -24,6 +24,9 @@ spring:
             # Hence why we change to client_secret_post
             client-authentication-method: client_secret_post
             provider: comfact
+          esigning:
+            authorization-grant-type: client_credentials
+            provider: esigning
 mdc:
   municipalityId:
     enabled: true
@@ -33,6 +36,9 @@ integration:
     connectTimeout: 5
     readTimeout: 30
   party:
+    connectTimeout: 5
+    readTimeout: 30
+  esigning:
     connectTimeout: 5
     readTimeout: 30
 

--- a/src/test/java/se/sundsvall/comfactfacade/TestUtil.java
+++ b/src/test/java/se/sundsvall/comfactfacade/TestUtil.java
@@ -1,0 +1,39 @@
+package se.sundsvall.comfactfacade;
+
+import generated.se.sundsvall.comfact.Action;
+import generated.se.sundsvall.comfact.Document;
+import generated.se.sundsvall.comfact.EventNotification;
+import generated.se.sundsvall.comfact.EventTrigger;
+import generated.se.sundsvall.comfact.SignatoryAction;
+import generated.se.sundsvall.comfact.SignatoryInfo;
+import generated.se.sundsvall.comfact.SigningInstanceInfo;
+import generated.se.sundsvall.comfact.Status;
+import java.nio.charset.StandardCharsets;
+import java.time.OffsetDateTime;
+
+public final class TestUtil {
+
+	private TestUtil() {}
+
+	public static EventNotification createEventNotification() {
+		return new EventNotification()
+			.eventTrigger(EventTrigger.SIGNING_INSTANCE_COMPLETED)
+			.signingInstanceInfo(new SigningInstanceInfo()
+				.signingInstanceId("comfact-123")
+				.customerReferenceNumber("550e8400-e29b-41d4-a716-446655440000")
+				.status(Status.COMPLETED)
+				.expires(OffsetDateTime.now().plusDays(30)))
+			.signatoryInfo(new SignatoryInfo()
+				.partyId("party-1")
+				.signatoryAction(new SignatoryAction()
+					.action(Action.APPROVED)
+					.reason("reason")
+					.timestamp(OffsetDateTime.now())))
+			.signedDocument(new Document()
+				.documentName("Contract")
+				.fileName("signed.pdf")
+				.mimeType("application/pdf")
+				.content("test".getBytes(StandardCharsets.UTF_8)))
+			.timestamp(OffsetDateTime.now());
+	}
+}

--- a/src/test/java/se/sundsvall/comfactfacade/api/EventNotificationResourceFailureTest.java
+++ b/src/test/java/se/sundsvall/comfactfacade/api/EventNotificationResourceFailureTest.java
@@ -1,0 +1,43 @@
+package se.sundsvall.comfactfacade.api;
+
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webtestclient.autoconfigure.AutoConfigureWebTestClient;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.reactive.server.WebTestClient;
+import se.sundsvall.comfactfacade.Application;
+import se.sundsvall.comfactfacade.service.EventNotificationService;
+
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.http.MediaType.APPLICATION_PROBLEM_JSON;
+import static se.sundsvall.comfactfacade.TestUtil.createEventNotification;
+
+@SpringBootTest(classes = Application.class, webEnvironment = RANDOM_PORT)
+@ActiveProfiles("junit")
+@AutoConfigureWebTestClient
+class EventNotificationResourceFailureTest {
+
+	@MockitoBean
+	private EventNotificationService eventNotificationServiceMock;
+
+	@Autowired
+	private WebTestClient webTestClient;
+
+	@Test
+	void handleComfactEvent_invalidMunicipalityId() {
+		webTestClient.post()
+			.uri(uriBuilder -> uriBuilder.path("/{municipalityId}/webhooks/comfact").build(Map.of("municipalityId", "invalid")))
+			.contentType(APPLICATION_JSON)
+			.bodyValue(createEventNotification())
+			.exchange()
+			.expectStatus().isBadRequest()
+			.expectHeader().contentType(APPLICATION_PROBLEM_JSON);
+
+		verifyNoInteractions(eventNotificationServiceMock);
+	}
+}

--- a/src/test/java/se/sundsvall/comfactfacade/api/EventNotificationResourceTest.java
+++ b/src/test/java/se/sundsvall/comfactfacade/api/EventNotificationResourceTest.java
@@ -1,0 +1,54 @@
+package se.sundsvall.comfactfacade.api;
+
+import generated.se.sundsvall.comfact.EventNotification;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webtestclient.autoconfigure.AutoConfigureWebTestClient;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.reactive.server.WebTestClient;
+import se.sundsvall.comfactfacade.Application;
+import se.sundsvall.comfactfacade.service.EventNotificationService;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static se.sundsvall.comfactfacade.Constants.MUNICIPALITY_ID;
+import static se.sundsvall.comfactfacade.TestUtil.createEventNotification;
+
+@SpringBootTest(classes = Application.class, webEnvironment = RANDOM_PORT)
+@ActiveProfiles("junit")
+@AutoConfigureWebTestClient
+class EventNotificationResourceTest {
+
+	@MockitoBean
+	private EventNotificationService eventNotificationServiceMock;
+
+	@Autowired
+	private WebTestClient webTestClient;
+
+	@Test
+	void handleComfactEvent() {
+		final var notification = createEventNotification();
+
+		webTestClient.post()
+			.uri(uriBuilder -> uriBuilder.path("/{municipalityId}/webhooks/comfact").build(Map.of("municipalityId", MUNICIPALITY_ID)))
+			.contentType(APPLICATION_JSON)
+			.bodyValue(notification)
+			.exchange()
+			.expectStatus().isOk();
+
+		final var captor = ArgumentCaptor.forClass(EventNotification.class);
+		verify(eventNotificationServiceMock).handleComfactEvent(eq(MUNICIPALITY_ID), captor.capture());
+		verifyNoMoreInteractions(eventNotificationServiceMock);
+
+		assertThat(captor.getValue().getSigningInstanceInfo().getSigningInstanceId()).isEqualTo("comfact-123");
+		assertThat(captor.getValue().getEventTrigger().getValue()).isEqualTo("signingInstanceCompleted");
+	}
+}

--- a/src/test/java/se/sundsvall/comfactfacade/integration/esigning/EsigningIntegrationTest.java
+++ b/src/test/java/se/sundsvall/comfactfacade/integration/esigning/EsigningIntegrationTest.java
@@ -1,0 +1,32 @@
+package se.sundsvall.comfactfacade.integration.esigning;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import se.sundsvall.comfactfacade.integration.esigning.model.ComfactEventNotification;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static se.sundsvall.comfactfacade.Constants.MUNICIPALITY_ID;
+
+@ExtendWith(MockitoExtension.class)
+class EsigningIntegrationTest {
+
+	@Mock
+	private EsigningClient esigningClientMock;
+
+	@InjectMocks
+	private EsigningIntegration integration;
+
+	@Test
+	void forwardComfactEvent() {
+		final var event = new ComfactEventNotification("ref", "comfact-123", "cust", "completed", null, null, null, null);
+
+		integration.forwardComfactEvent(MUNICIPALITY_ID, event);
+
+		verify(esigningClientMock).forwardComfactEvent(MUNICIPALITY_ID, event);
+		verifyNoMoreInteractions(esigningClientMock);
+	}
+}

--- a/src/test/java/se/sundsvall/comfactfacade/integration/esigning/configuration/EsigningConfigurationTest.java
+++ b/src/test/java/se/sundsvall/comfactfacade/integration/esigning/configuration/EsigningConfigurationTest.java
@@ -1,0 +1,71 @@
+package se.sundsvall.comfactfacade.integration.esigning.configuration;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.cloud.openfeign.FeignBuilderCustomizer;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import se.sundsvall.dept44.configuration.feign.FeignMultiCustomizer;
+import se.sundsvall.dept44.configuration.feign.decoder.ProblemErrorDecoder;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anySet;
+import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static se.sundsvall.comfactfacade.integration.esigning.configuration.EsigningConfiguration.CLIENT_ID;
+
+@ExtendWith(MockitoExtension.class)
+class EsigningConfigurationTest {
+
+	@Spy
+	private FeignMultiCustomizer feignMultiCustomizerSpy;
+
+	@Mock
+	private FeignBuilderCustomizer feignBuilderCustomizerMock;
+
+	@Mock
+	private EsigningProperties propertiesMock;
+
+	@Mock
+	private ClientRegistrationRepository clientRegistrationRepositoryMock;
+
+	@Mock
+	private ClientRegistration clientRegistrationMock;
+
+	@Test
+	void testFeignBuilderCustomizer() {
+		final var configuration = new EsigningConfiguration();
+
+		when(clientRegistrationRepositoryMock.findByRegistrationId(any())).thenReturn(clientRegistrationMock);
+		when(propertiesMock.connectTimeout()).thenReturn(1);
+		when(propertiesMock.readTimeout()).thenReturn(2);
+		when(feignMultiCustomizerSpy.composeCustomizersToOne()).thenReturn(feignBuilderCustomizerMock);
+
+		try (final MockedStatic<FeignMultiCustomizer> feignMultiCustomizerMock = Mockito.mockStatic(FeignMultiCustomizer.class)) {
+			feignMultiCustomizerMock.when(FeignMultiCustomizer::create).thenReturn(feignMultiCustomizerSpy);
+
+			final var customizer = configuration.feignBuilderCustomizer(propertiesMock, clientRegistrationRepositoryMock);
+			final var errorDecoderCaptor = ArgumentCaptor.forClass(ProblemErrorDecoder.class);
+
+			verify(feignMultiCustomizerSpy).withErrorDecoder(errorDecoderCaptor.capture());
+			verify(clientRegistrationRepositoryMock).findByRegistrationId(CLIENT_ID);
+			verify(feignMultiCustomizerSpy).withRetryableOAuth2InterceptorForClientRegistration(same(clientRegistrationMock), anySet());
+			verify(propertiesMock).connectTimeout();
+			verify(propertiesMock).readTimeout();
+			verify(feignMultiCustomizerSpy).withRequestTimeoutsInSeconds(1, 2);
+			verify(feignMultiCustomizerSpy).composeCustomizersToOne();
+
+			assertThat(errorDecoderCaptor.getValue()).hasFieldOrPropertyWithValue("integrationName", CLIENT_ID);
+			assertThat(customizer).isSameAs(feignBuilderCustomizerMock);
+		}
+	}
+
+}

--- a/src/test/java/se/sundsvall/comfactfacade/integration/esigning/configuration/EsigningPropertiesTest.java
+++ b/src/test/java/se/sundsvall/comfactfacade/integration/esigning/configuration/EsigningPropertiesTest.java
@@ -1,0 +1,24 @@
+package se.sundsvall.comfactfacade.integration.esigning.configuration;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import se.sundsvall.comfactfacade.Application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(classes = Application.class)
+@ActiveProfiles("junit")
+class EsigningPropertiesTest {
+
+	@Autowired
+	private EsigningProperties properties;
+
+	@Test
+	void testProperties() {
+		assertThat(properties.connectTimeout()).isEqualTo(5);
+		assertThat(properties.readTimeout()).isEqualTo(30);
+	}
+
+}

--- a/src/test/java/se/sundsvall/comfactfacade/service/EventNotificationMapperTest.java
+++ b/src/test/java/se/sundsvall/comfactfacade/service/EventNotificationMapperTest.java
@@ -1,0 +1,56 @@
+package se.sundsvall.comfactfacade.service;
+
+import generated.se.sundsvall.comfact.SignatoryInfo;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static se.sundsvall.comfactfacade.TestUtil.createEventNotification;
+
+class EventNotificationMapperTest {
+
+	@Test
+	void toEsigningEvent() {
+		final var notification = createEventNotification();
+
+		final var event = EventNotificationMapper.toEsigningEvent(notification);
+
+		assertThat(event.eventTrigger()).isEqualTo("signingInstanceCompleted");
+		assertThat(event.signingInstanceId()).isEqualTo("comfact-123");
+		assertThat(event.customerReference()).isEqualTo("550e8400-e29b-41d4-a716-446655440000");
+		assertThat(event.statusCode()).isEqualTo("completed");
+		assertThat(event.expires()).isEqualTo(notification.getSigningInstanceInfo().getExpires());
+		assertThat(event.timestamp()).isEqualTo(notification.getTimestamp());
+
+		assertThat(event.signatory()).isNotNull();
+		assertThat(event.signatory().partyId()).isEqualTo("party-1");
+		assertThat(event.signatory().action()).isEqualTo("approved");
+		assertThat(event.signatory().reason()).isEqualTo("reason");
+
+		assertThat(event.signedDocument()).isNotNull();
+		assertThat(event.signedDocument().getName()).isEqualTo("Contract");
+		assertThat(event.signedDocument().getFileName()).isEqualTo("signed.pdf");
+		assertThat(event.signedDocument().getMimeType()).isEqualTo("application/pdf");
+		assertThat(event.signedDocument().getContent()).isEqualTo("dGVzdA==");
+	}
+
+	@Test
+	void toEsigningEvent_noSignatoryOrDocument() {
+		final var notification = createEventNotification().signatoryInfo(null).signedDocument(null);
+
+		final var event = EventNotificationMapper.toEsigningEvent(notification);
+
+		assertThat(event.signatory()).isNull();
+		assertThat(event.signedDocument()).isNull();
+	}
+
+	@Test
+	void toEsigningEvent_signatoryWithoutAction() {
+		final var notification = createEventNotification().signatoryInfo(new SignatoryInfo().partyId("party-9"));
+
+		final var event = EventNotificationMapper.toEsigningEvent(notification);
+
+		assertThat(event.signatory().partyId()).isEqualTo("party-9");
+		assertThat(event.signatory().action()).isNull();
+		assertThat(event.signatory().reason()).isNull();
+	}
+}

--- a/src/test/java/se/sundsvall/comfactfacade/service/EventNotificationServiceTest.java
+++ b/src/test/java/se/sundsvall/comfactfacade/service/EventNotificationServiceTest.java
@@ -1,0 +1,33 @@
+package se.sundsvall.comfactfacade.service;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import se.sundsvall.comfactfacade.integration.esigning.EsigningIntegration;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static se.sundsvall.comfactfacade.Constants.MUNICIPALITY_ID;
+import static se.sundsvall.comfactfacade.TestUtil.createEventNotification;
+
+@ExtendWith(MockitoExtension.class)
+class EventNotificationServiceTest {
+
+	@Mock
+	private EsigningIntegration esigningIntegrationMock;
+
+	@InjectMocks
+	private EventNotificationService service;
+
+	@Test
+	void handleComfactEvent() {
+		final var notification = createEventNotification();
+
+		service.handleComfactEvent(MUNICIPALITY_ID, notification);
+
+		verify(esigningIntegrationMock).forwardComfactEvent(MUNICIPALITY_ID, EventNotificationMapper.toEsigningEvent(notification));
+		verifyNoMoreInteractions(esigningIntegrationMock);
+	}
+}


### PR DESCRIPTION
## What

Adds the inbound **Comfact → comfact-facade → e-signing** hop for the Postportalen e-signing gateway.

Chain: `Comfact → comfact-facade POST /{municipalityId}/webhooks/comfact → api-service-e-signing POST /{municipalityId}/e-signing/webhooks/comfact`.

Comfact's webhook target is configured account-side (one account = one municipality), so the municipality is baked into the URL. The receiver flattens Comfact's `EventNotification` and forwards it to e-signing, which owns the normalization into a provider-neutral event for pps.

## Changes

- `api/EventNotificationResource` — receives the generated `EventNotification` at `POST /{municipalityId}/webhooks/comfact`.
- `service/EventNotificationMapper` + `EventNotificationService` — flatten the event to the forward DTO and delegate.
- `integration/esigning/**` — new Feign client (`@CircuitBreaker`, oauth2 client-credentials registration `esigning`), forward DTOs (`ComfactEventNotification`, `ComfactSignatory`), config/properties.
- `application{,-junit,-it}.yml` — `esigning` integration + oauth2 config.

## Design notes

- **`EsigningConfiguration` mirrors `PartyConfiguration`, not `ComfactConfiguration`** — it is a plain `@Import` class (not `@Configuration`), so its `feignBuilderCustomizer` bean is scoped to its own Feign client context. A `@Configuration` variant collides with Comfact's global bean (`BeanDefinitionOverrideException`). Properties register via `@ServiceApplication`'s config-properties scan.
- **The webhook is `@Hidden` from OpenAPI.** It is called only by Comfact, never by Sundsvall services. Exposing the generated `EventNotification` pulls `generated…comfact.Document` into springdoc, which collides on schema name `Document` with the facade's own `api.model.Document` and corrupts the existing signing-endpoint contract. Hiding it keeps the public contract untouched.

## Testing

`mvn verify` green — 117 tests (9 new), JaCoCo ≥85% line+branch, OpenAPI contract IT unchanged.

## Coordinated work (separate tickets)

- **api-service-e-signing:** PR #50 consumes this forwarded event at `/e-signing/webhooks/comfact` and normalizes it into the neutral `SigningEvent` for pps.
- **pps:** send MessageId as `customerReference` at create, consume `SigningEvent`, add `SigningEntity` + recipient signing-status model.