### PR TITLE
Bump version 3.0 → 3.1 (Comfact webhook receiver)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 	</parent>
 	<groupId>se.sundsvall</groupId>
 	<artifactId>api-comfact-facade</artifactId>
-	<version>3.0</version>
+	<version>3.1</version>
 	<name>api-comfact-facade</name>
 	<properties>
 		<generated-sources-path>${project.build.directory}/generated-sources</generated-sources-path>

--- a/src/integration-test/resources/openapi.yml
+++ b/src/integration-test/resources/openapi.yml
@@ -5,7 +5,7 @@ info:
   license:
     name: MIT License
     url: https://opensource.org/licenses/MIT
-  version: "3.0"
+  version: "3.1"
 servers:
   - url: http://localhost:59777
     description: Generated server url


### PR DESCRIPTION
Steps the module minor version for the Comfact webhook receiver (#77, event-notification → e-signing relay), which was added while the version was already at 3.0 (set by an earlier, unrelated change). Two-line change: pom `<version>` + the checked-in openapi `info.version`.